### PR TITLE
NodeJS folder renamed to nodejs

### DIFF
--- a/start.py
+++ b/start.py
@@ -235,7 +235,7 @@ def writeNodeJSService(project, repo):
                 '/usr/src/app/node_modules'
             ]
         }
-        writeService(project, repo, 'NodeJS', extra)
+        writeService(project, repo, 'nodejs', extra)
     except Exception, e:
         sys.exit(1)
 


### PR DESCRIPTION
En CentOS da un error que no encuentra el Dockerfile en ./NodeJS/Dockerfile, le cambié el nombre al folder y funcionó